### PR TITLE
create a hidden space at the start of a row

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
                 padding-top: 50px;
                 padding-bottom: 20px;
             }
+            .row:before {
+              height: 35px;   /* equal to the header height */
+              margin-top: -35px;  /* negative margin equal to the header height */
+              visibility: hidden;
+              content: "";
+            }
         </style>
         <link rel="stylesheet" href="https://cdn.knightlab.com/libs/juxtapose/latest/css/juxtapose.css">
         <link rel="stylesheet" href="css/main.css">


### PR DESCRIPTION
Since some photos don't have the title on the image, we loose context when using #anchors to go directly to content.
This commit uses the :before pseudo class to add a hidden space the size with the size of the top bar to add some offset to the scroll, when using the #anchor.